### PR TITLE
Removed the extra comments that broke the Docker build

### DIFF
--- a/detectron/ops/zero_even_op.cc
+++ b/detectron/ops/zero_even_op.cc
@@ -1,12 +1,9 @@
 /**
-/**
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
- */
-
  */
 
 #include "zero_even_op.h"

--- a/detectron/ops/zero_even_op.cu
+++ b/detectron/ops/zero_even_op.cu
@@ -1,12 +1,9 @@
 /**
-/**
 # Copyright (c) Facebook, Inc. and its affiliates.
 # All rights reserved.
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
- */
-
  */
 
 #include "caffe2/core/context_gpu.h"


### PR DESCRIPTION
I attempted to build a Docker image based on the [instructions](https://github.com/facebookresearch/DensePose/blob/master/INSTALL.md#docker-image), but I was running into build errors until I removed the extra comments in these ops. After making this change, I was able to build the image and run `test_batch_permutation_op.py` correctly, though I haven't tried to run anything else after this point.