### PR TITLE
Fix building ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(caffe2_detectron_custom_ops caffe2_library)
 install(TARGETS caffe2_detectron_custom_ops DESTINATION lib)
 
 # Install custom GPU ops lib, if gpu is present.
-if (${CAFFE2_FOUND_CUDA})
+if (${CAFFE2_USE_CUDA})
   # Additional -I prefix is required for CMake versions before commit (< 3.7):
   # https://github.com/Kitware/CMake/commit/7ded655f7ba82ea72a82d0555449f2df5ef38594
   list(APPEND CUDA_INCLUDE_DIRS -I${CAFFE2_INCLUDE_DIRS})


### PR DESCRIPTION
CMake variable that tells whether CUDA has been found was renamed in 78b88219 to `CAFFE2_USE_CUDA` (see [pytorch repo](https://github.com/pytorch/pytorch)). This causes `make ops` to not generate GPU ops library.