### PR TITLE
check for both, CAFFE2_USE_CUDA or CAFFE2_FOUND_CUDA variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(caffe2_detectron_custom_ops caffe2_library)
 install(TARGETS caffe2_detectron_custom_ops DESTINATION lib)
 
 # Install custom GPU ops lib, if gpu is present.
-if (${CAFFE2_USE_CUDA})
+if (${CAFFE2_USE_CUDA} OR ${CAFFE2_FOUND_CUDA})
   # Additional -I prefix is required for CMake versions before commit (< 3.7):
   # https://github.com/Kitware/CMake/commit/7ded655f7ba82ea72a82d0555449f2df5ef38594
   list(APPEND CUDA_INCLUDE_DIRS -I${CAFFE2_INCLUDE_DIRS})


### PR DESCRIPTION
fixes #16, #14 
PyTorch/Caffe2 cmake configuration file changed the variable name from CAFFE2_FOUND_CUDA to CAFFE2_USE_CUDA (see PR [8248](https://github.com/pytorch/pytorch/pull/8248), commit [78b88219](https://github.com/pytorch/pytorch/commit/78b88219fac30b3a30cfdbe86db200ed75fa4d76)). To support both cases (fresh and existing installs of caffe2), I suggest to test for both.