### PR TITLE
Fix links annotations in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,9 +108,9 @@ ln -s /path/to/coco $DENSEPOSE/detectron/datasets/data/coco
 Create symlinks for the DensePose-COCO annotations
 
 ```
-ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_minival.json $DETECTRON/detectron/datasets/data/coco/annotations/
-ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_minival.json $DETECTRON/detectron/datasets/data/coco/annotations/
-ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_minival.json $DETECTRON/detectron/datasets/data/coco/annotations/
+ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_minival.json $DENSEPOSE/detectron/datasets/data/coco/annotations/
+ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_train.json $DENSEPOSE/detectron/datasets/data/coco/annotations/
+ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_valminusminus.json $DENSEPOSE/detectron/datasets/data/coco/annotations/
 ```
 
 Your local COCO dataset copy at `/path/to/coco` should have the following directory structure:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,7 +110,7 @@ Create symlinks for the DensePose-COCO annotations
 ```
 ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_minival.json $DENSEPOSE/detectron/datasets/data/coco/annotations/
 ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_train.json $DENSEPOSE/detectron/datasets/data/coco/annotations/
-ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_valminusminus.json $DENSEPOSE/detectron/datasets/data/coco/annotations/
+ln -s $DENSEPOSE/DensePoseData/DensePose_COCO/densepose_coco_2014_valminusminival.json $DENSEPOSE/detectron/datasets/data/coco/annotations/
 ```
 
 Your local COCO dataset copy at `/path/to/coco` should have the following directory structure:


### PR DESCRIPTION
One symbolic link to _densepose_coco_2014_minival.json_ is repeated thrice. I've changed them to _densepose_coco_2014_minival.json_, _densepose_coco_2014_train.json_ and _densepose_coco_2014_valminusminus.json_ accordingly.
Also, change `$DETECTRON` to `$DENSEPOSE`.