### PR TITLE
Update docker image setup instructions to make data accessible

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,9 +26,3 @@ RUN make
 
 # [Optional] Build custom ops
 RUN make ops
-
-# Fetch data
-WORKDIR /densepose/DensePoseData
-RUN /bin/bash -c /densepose/DensePoseData/get_DensePose_COCO.sh
-RUN /bin/bash -c /densepose/DensePoseData/get_densepose_uv.sh
-RUN /bin/bash -c /densepose/DensePoseData/get_eval_data.sh


### PR DESCRIPTION
fixes #22 
The best way to set up docker training would be to prepare all the required data on the host and mount it in the docker container. Installation instructions for docker were adjusted and tested.