### PR TITLE
remove keypoints eval assertion to allow multihead testing

### DIFF
--- a/detectron/datasets/task_evaluation.py
+++ b/detectron/datasets/task_evaluation.py
@@ -132,8 +132,8 @@ def evaluate_keypoints(dataset, all_boxes, all_keyps, output_dir):
     """Evaluate human keypoint detection (i.e., 2D pose estimation)."""
     logger.info('Evaluating detections')
     not_comp = not cfg.TEST.COMPETITION_MODE
-    assert dataset.name.startswith('keypoints_coco_'), \
-        'Only COCO keypoints are currently supported'
+    #assert dataset.name.startswith('keypoints_coco_'), \
+    #    'Only COCO keypoints are currently supported'
     coco_eval = json_dataset_evaluator.evaluate_keypoints(
         dataset,
         all_boxes,


### PR DESCRIPTION
DensePose annotations contain keypoints and thus allow to train models with multiple heads (bodyUV, mask, keypoints etc). However, when testing such models, keypoints evaluation is doing a hardcoded check for dataset name, which fails for DensePose annotations. I suggest to remove this check to allow for training of models with multiple heads.