### PR TITLE
naming directories with the prefix "coco_" causes assertion error

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,11 +117,11 @@ Your local COCO dataset copy at `/path/to/coco` should have the following direct
 
 ```
 coco
-|_ coco_train2014
+|_ train2014
 |  |_ <im-1-name>.jpg
 |  |_ ...
 |  |_ <im-N-name>.jpg
-|_ coco_val2014
+|_ val2014
 |_ ...
 |_ annotations
    |_ instances_train2014.json


### PR DESCRIPTION
i renamed my coco folders from their default names ("train2014") to the names specified in the documentation which results in this error:

INFO train.py: 171: Loading dataset: ('dense_coco_2014_train', 'dense_coco_2014_valminusminival')
Traceback (most recent call last):
  File "tools/train_net.py", line 119, in <module>
    main()
  File "tools/train_net.py", line 101, in main
    checkpoints = detectron.utils.train.train_model()
  File "/densepose/detectron/utils/train.py", line 50, in train_model
    setup_model_for_training(model, weights_file, output_dir)
  File "/densepose/detectron/utils/train.py", line 149, in setup_model_for_training
    add_model_training_inputs(model)
  File "/densepose/detectron/utils/train.py", line 173, in add_model_training_inputs
    cfg.TRAIN.DATASETS, cfg.TRAIN.PROPOSAL_FILES
  File "/densepose/detectron/datasets/roidb.py", line 53, in combined_roidb_for_training
    roidbs = [get_roidb(*args) for args in zip(dataset_names, proposal_files)]
  File "/densepose/detectron/datasets/roidb.py", line 34, in get_roidb
    ds = JsonDataset(dataset_name)
  File "/densepose/detectron/datasets/json_dataset.py", line 49, in __init__
    'Im dir \'{}\' not found'.format(dataset_catalog.get_im_dir(name))
AssertionError: Im dir '/densepose/detectron/datasets/data/coco/train2014' not found

I'd like to see the documentation corrected because its already difficult enough to get this software working without silly gotcha's like this.
