### PR TITLE
Fixed Issue with pyyaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.13
-pyyaml>=3.12
+pyyaml==3.12
 matplotlib
 opencv-python>=3.2
 setuptools


### PR DESCRIPTION
Requires pyyaml version 3.12 (instead of >= 3.12) since some users reported problems with the latest version of pyyaml [#225](https://github.com/facebookresearch/DensePose/issues/225) [#216](https://github.com/facebookresearch/DensePose/issues/216)