### PR TITLE
prerequisite for installing

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,8 +37,18 @@ Install the [COCO API](https://github.com/cocodataset/cocoapi):
 # COCOAPI=/path/to/clone/cocoapi
 git clone https://github.com/cocodataset/cocoapi.git $COCOAPI
 cd $COCOAPI/PythonAPI
+
+#pre install some requirements before install not to make error like 'pycocotools/_mask.c: No such file or directory '
+# pycocotools needs matplotlib, Cython in advance, so this installation process has to be in right order.
+pip install Cython
+python -m pip install matplotlib
+pip install pycocotools 
+
+
 # Install into global site-packages
-make install
+make install 
+
+
 # Alternatively, if you do not have permissions or prefer
 # not to install the COCO API into global site-packages
 python2 setup.py install --user


### PR DESCRIPTION
there is  
error: pycocotools/_mask.c: No such file or directory
after doing command 'make install' 
so I add some prerequisite for Cython, Matplotlib(not pip install Matplotlib resolves this error), pycocotools 